### PR TITLE
エラーハンドリング追加

### DIFF
--- a/src/main/java/com/example/demo/app/controllers/CustomizeErrorController.java
+++ b/src/main/java/com/example/demo/app/controllers/CustomizeErrorController.java
@@ -1,0 +1,55 @@
+package com.example.demo.app.controllers;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+@RequestMapping("/error")
+public class CustomizeErrorController implements ErrorController {
+
+    @Override
+    public String getErrorPath() {
+        return "/error";
+    }
+
+    /**
+     * レスポンス用の ModelAndView オブジェクトを返す。
+     *
+     * @param req リクエスト情報
+     * @param mav レスポンス情報
+     * @return HTML レスポンス用の ModelAndView オブジェクト
+     */
+    @RequestMapping
+    public ModelAndView error(HttpServletRequest req, ModelAndView mav) {
+
+        String mainErrorMsg = "アクセスしようとしたページはシステムエラーのため、アクセスできませんでした。";
+        String subErrorMsg = "大変申し訳ありませんが、しばらく時間をおいてからもう一度アクセスしてくださいますようお願いいたします。";
+
+        // HTTP ステータスを決める
+        // ここでは 404 以外は全部 500 にする
+        Object statusCode = req.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        if (statusCode != null && statusCode.toString().equals("404")) {
+            status = HttpStatus.NOT_FOUND;
+            mainErrorMsg = "指定されたURLは存在しませんでした。";
+            subErrorMsg = "URLが正しく入力されていないか、このページが削除された可能性があります。";
+        }
+
+        mav.setStatus(status);
+        mav.addObject("mainErrorMsg", mainErrorMsg);
+        mav.addObject("subErrorMsg", subErrorMsg);
+
+        // ビュー名を指定する
+        // Thymeleaf テンプレート src/main/resources/templates/error.html を使用
+        mav.setViewName("error");
+
+        return mav;
+    }
+
+}

--- a/src/main/java/com/example/demo/app/controllers/DemoController.java
+++ b/src/main/java/com/example/demo/app/controllers/DemoController.java
@@ -25,7 +25,7 @@ public class DemoController {
     }
 
     @GetMapping("/{prefectureId}")
-    public String prefectureDetail(@PathVariable int prefectureId, Model model) {
+    public String prefectureDetail(@PathVariable int prefectureId, Model model) throws Exception {
         model.addAttribute("prefectureDetail", demoService.getPrefectureDetail(prefectureId));
         model.addAttribute("prefectures", demoService.getPrefectures());
         return "index";

--- a/src/main/java/com/example/demo/domain/services/DemoService.java
+++ b/src/main/java/com/example/demo/domain/services/DemoService.java
@@ -7,6 +7,7 @@ import com.example.demo.domain.dao.entity.RegionEntity;
 import com.example.demo.domain.repositories.PrefectureRepository;
 import com.example.demo.domain.repositories.RegionRepository;
 
+import org.apache.ibatis.javassist.NotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -28,7 +29,8 @@ public class DemoService {
         return prefectureRepository.findAll();
     }
 
-    public PrefectureEntity getPrefectureDetail(int prefectureId) {
-        return prefectureRepository.findById(prefectureId).orElseThrow(RuntimeException::new);
+    public PrefectureEntity getPrefectureDetail(int prefectureId) throws Exception {
+        return prefectureRepository.findById(prefectureId)
+                .orElseThrow(() -> new NotFoundException("Not founded this prefecture id=" + prefectureId));
     }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -10,7 +10,16 @@ body {
         max-width: 970px;
     }
 }
+.font14{
+    font-size: 14px;
+}
 
+/* フッター */
+#footer {
+    border-top: 1px solid #ebebeb;
+}
+
+/* ヘッダー */
 #header {
     font-size: small;
 }
@@ -20,6 +29,12 @@ body {
     background-color: #f7f7f8;
 }
 
+/* エラーページ */
+#root-link {
+    margin-bottom: 180px;
+}
+
+/* インデックス */
 #web-search-form > div > input {
     height: 26px;
     font-size: 12px;
@@ -140,3 +155,5 @@ body {
 .prefecture-text {
     font-size: 18px;
 }
+
+

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{components/template :: layout(~{::title},~{::body/content()})}">
+
+<head>
+    <title>システムエラー</title>
+</head>
+
+<body>
+    <div class="text-center p-3">
+        <p class="mt-3 h6" th:text="${mainErrorMsg}"></p>
+        <p class="font14" th:text="${subErrorMsg}"></p>
+        <p id="root-link" class="font14"><a th:href="@{/}">デモ</a></p>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
■対応内容
・エラーハンドリングの追加
→ 存在しないパスの場合は404、それ以外のエラーは500を返し、別々のエラーメッセージに変更
![システムエラー](https://user-images.githubusercontent.com/20121469/90105156-69467900-dd80-11ea-86e0-e03a3cf8a6a3.png)
![404](https://user-images.githubusercontent.com/20121469/90105287-9bf07180-dd80-11ea-966a-13c84360844b.png)
